### PR TITLE
Refactor Go Sprintf statements using Comby

### DIFF
--- a/builtin/providers/terraform/flatten.go
+++ b/builtin/providers/terraform/flatten.go
@@ -37,7 +37,7 @@ func flatten(result map[string]string, prefix string, v reflect.Value) {
 			result[prefix] = "false"
 		}
 	case reflect.Int:
-		result[prefix] = fmt.Sprintf("%d", v.Int())
+		result[prefix] = strconv.Itoa(v.Int())
 	case reflect.Map:
 		flattenMap(result, prefix, v)
 	case reflect.Slice:
@@ -52,7 +52,7 @@ func flatten(result map[string]string, prefix string, v reflect.Value) {
 func flattenMap(result map[string]string, prefix string, v reflect.Value) {
 	mapKeys := v.MapKeys()
 
-	result[fmt.Sprintf("%s.%%", prefix)] = fmt.Sprintf("%d", len(mapKeys))
+	result[fmt.Sprintf("%s.%%", prefix)] = strconv.Itoa(len(mapKeys))
 	for _, k := range mapKeys {
 		if k.Kind() == reflect.Interface {
 			k = k.Elem()
@@ -69,7 +69,7 @@ func flattenMap(result map[string]string, prefix string, v reflect.Value) {
 func flattenSlice(result map[string]string, prefix string, v reflect.Value) {
 	prefix = prefix + "."
 
-	result[prefix+"#"] = fmt.Sprintf("%d", v.Len())
+	result[prefix+"#"] = strconv.Itoa(v.Len())
 	for i := 0; i < v.Len(); i++ {
 		flatten(result, fmt.Sprintf("%s%d", prefix, i), v.Index(i))
 	}

--- a/builtin/providers/test/resource_computed_set.go
+++ b/builtin/providers/test/resource_computed_set.go
@@ -103,7 +103,7 @@ func testResourceComputedSetRead(d *schema.ResourceData, meta interface{}) error
 
 	var set []interface{}
 	for i := 0; i < count; i++ {
-		set = append(set, fmt.Sprintf("%d", i))
+		set = append(set, strconv.Itoa(i))
 	}
 
 	d.Set("string_set", schema.NewSet(schema.HashString, set))

--- a/command/format/state_test.go
+++ b/command/format/state_test.go
@@ -74,7 +74,7 @@ func TestState(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			got := State(tt.State)
 			if got != tt.Want {
 				t.Errorf(

--- a/command/hook_ui_test.go
+++ b/command/hook_ui_test.go
@@ -299,7 +299,7 @@ func TestTruncateId(t *testing.T) {
 		},
 	}
 	for i, tc := range testCases {
-		testName := fmt.Sprintf("%d", i)
+		testName := strconv.Itoa(i)
 		t.Run(testName, func(t *testing.T) {
 			out := truncateId(tc.Input, tc.MaxLen)
 			if out != tc.Expected {

--- a/command/testdata/login-oauth-server/oauthserver.go
+++ b/command/testdata/login-oauth-server/oauthserver.go
@@ -77,7 +77,7 @@ func (h handler) serveAuthz(resp http.ResponseWriter, req *http.Request) {
 
 	respBody := fmt.Sprintf(`<a href="%s">Log In and Consent</a>`, html.EscapeString(redirectURL.String()))
 	resp.Header().Set("Content-Type", "text/html")
-	resp.Header().Set("Content-Length", fmt.Sprintf("%d", len(respBody)))
+	resp.Header().Set("Content-Length", strconv.Itoa(len(respBody)))
 	resp.Header().Set("X-Redirect-To", redirectURL.String()) // For robotic clients, using webbrowser.MockLauncher
 	resp.WriteHeader(200)
 	resp.Write([]byte(respBody))

--- a/flatmap/flatten.go
+++ b/flatmap/flatten.go
@@ -35,7 +35,7 @@ func flatten(result map[string]string, prefix string, v reflect.Value) {
 			result[prefix] = "false"
 		}
 	case reflect.Int:
-		result[prefix] = fmt.Sprintf("%d", v.Int())
+		result[prefix] = strconv.Itoa(v.Int())
 	case reflect.Map:
 		flattenMap(result, prefix, v)
 	case reflect.Slice:
@@ -64,7 +64,7 @@ func flattenMap(result map[string]string, prefix string, v reflect.Value) {
 func flattenSlice(result map[string]string, prefix string, v reflect.Value) {
 	prefix = prefix + "."
 
-	result[prefix+"#"] = fmt.Sprintf("%d", v.Len())
+	result[prefix+"#"] = strconv.Itoa(v.Len())
 	for i := 0; i < v.Len(); i++ {
 		flatten(result, fmt.Sprintf("%s%d", prefix, i), v.Index(i))
 	}

--- a/helper/hashcode/hashcode.go
+++ b/helper/hashcode/hashcode.go
@@ -31,5 +31,5 @@ func Strings(strings []string) string {
 		buf.WriteString(fmt.Sprintf("%s-", s))
 	}
 
-	return fmt.Sprintf("%d", String(buf.String()))
+	return strconv.Itoa(String(buf.String()))
 }

--- a/helper/plugin/grpc_provider_test.go
+++ b/helper/plugin/grpc_provider_test.go
@@ -1294,7 +1294,7 @@ func TestNormalizeNullValues(t *testing.T) {
 			Apply: true,
 		},
 	} {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			got := normalizeNullValues(tc.Dst, tc.Src, tc.Apply)
 			if !got.RawEquals(tc.Expect) {
 				t.Fatalf("\nexpected: %#v\ngot:      %#v\n", tc.Expect, got)

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -1662,7 +1662,7 @@ func TestResource_migrateAndUpgrade(t *testing.T) {
 	}
 
 	for i, s := range testStates {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			newState, err := r.Refresh(s, nil)
 			if err != nil {
 				t.Fatal(err)

--- a/helper/variables/flag_any_test.go
+++ b/helper/variables/flag_any_test.go
@@ -267,7 +267,7 @@ foo = {
 	path := testTempFile(t)
 
 	for i, tc := range cases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			var input []string
 			switch i := tc.Input.(type) {
 			case string:

--- a/helper/variables/flag_file_test.go
+++ b/helper/variables/flag_file_test.go
@@ -75,7 +75,7 @@ foo = {
 	path := testTempFile(t)
 
 	for i, tc := range cases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			var input []string
 			switch i := tc.Input.(type) {
 			case string:

--- a/httpclient/useragent_test.go
+++ b/httpclient/useragent_test.go
@@ -29,7 +29,7 @@ func TestUserAgentString_env(t *testing.T) {
 		{fmt.Sprintf("%s test/3", expectedBase), " test/3 "},
 		{fmt.Sprintf("%s test/4", expectedBase), "test/4 \n"},
 	} {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			if c.additional == "" {
 				os.Unsetenv(uaEnvVar)
 			} else {
@@ -66,7 +66,7 @@ func TestUserAgentAppendViaEnvVar(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			os.Unsetenv(uaEnvVar)
 			os.Setenv(uaEnvVar, tc.envVarValue)
 			givenUA := TerraformUserAgent("0.0.0")

--- a/terraform/diff_test.go
+++ b/terraform/diff_test.go
@@ -1193,7 +1193,7 @@ func TestInstanceDiffSame(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			same, reason := tc.One.Same(tc.Two)
 			if same != tc.Same {
 				t.Fatalf("%d: expected same: %t, got %t (%s)\n\n one: %#v\n\ntwo: %#v",


### PR DESCRIPTION
This campaign refactors Go code by replacing `fmt.Sprintf("%d", number)` statements with the equivalent but clearer `strconv.Itoa(number)`.

It uses [Comby](https://comby.dev) to do the replacement and then runs `gofmt` over the repositories.

Here is the action definition:

```json
{
  "scopeQuery": "lang:go fmt.Sprintf(\"%d\", fork:yes -repo:sourcegraph-testing/go",
  "steps": [
    {
      "type": "docker", "image": "comby/comby",
      "args": [ "-in-place", "fmt.Sprintf(\"%d\", :[v])", "strconv.Itoa(:[v])", ".go", "-matcher", ".go", "-d", "/work", "-exclude-dir", ".,vendor" ]
    },
    { "type": "docker", "image": "golang:1.14-alpine", "args": ["sh", "-c", "cd /work && go fmt ./..."] }
  ]
}
```